### PR TITLE
Fix the Nim path in zsh on Ubuntu 19.10

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -24,7 +24,7 @@ export GO111MODULE=on
 
 #- make it an absolute path, so we can call this script from other dirs
 #- we can't use native Windows paths in here, because colons can't be escaped in PATH
-export PATH="${ABS_PATH}/../../Nim/bin:${GOPATH}/bin:${PATH}"
+export PATH="$(realpath ${ABS_PATH}/../../Nim/bin):${GOPATH}/bin:${PATH}"
 
 # Nimble needs this to be an absolute path
 export NIMBLE_DIR="${ABS_PATH}/../../.nimble"


### PR DESCRIPTION
Without this fix my system was failing to locate the correct nim
executable even though my env PATH was featuring a correct entry
near the top. The entry had ../.. fragments which I suspected to
be the source of problems.