### PR TITLE
Alternative fix for the Nim path problem in zsh

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -24,9 +24,11 @@ export NIMBUS_ENV_DIR="${ABS_PATH}"
 export GOPATH="${ABS_PATH}/../../go"
 export GO111MODULE=on
 
+export NIM_PATH=$(cd "${ABS_PATH}/../vendor/Nim/bin"; pwd)
+
 #- make it an absolute path, so we can call this script from other dirs
 #- we can't use native Windows paths in here, because colons can't be escaped in PATH
-export PATH="${ABS_PATH}/../vendor/Nim/bin:${GOPATH}/bin:${PATH}"
+export PATH="${NIM_PATH}:${GOPATH}/bin:${PATH}"
 
 # Nimble needs this to be an absolute path
 export NIMBLE_DIR="${ABS_PATH}/../../.nimble"


### PR DESCRIPTION
`source env.sh` works better in zsh now, but I still have the Nim PATH issue, so this is an alternative way to fix it that doesn't rely on `realpath`.

Obsoletes https://github.com/status-im/nimbus-build-system/pull/1