### PR TITLE
set params for dynamically linked pcre only if OS is not Win/macOS

### DIFF
--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -33,7 +33,9 @@ endif
 
 # avoid a "libpcre.so.3: cannot open shared object file: No such file or directory" message, where possible
 ifneq ($(OS), Windows_NT)
-  NIM_PARAMS := $(NIM_PARAMS) -d:usePcreHeader --passL:"-lpcre"
+  ifneq ($(strip $(shell uname)), Darwin)
+    NIM_PARAMS := $(NIM_PARAMS) -d:usePcreHeader --passL:\"-lpcre\"
+  endif
 endif
 
 # guess who does parsing before variable expansion


### PR DESCRIPTION
In the nim-status-client project I'm [statically linking libpcre](https://github.com/status-im/nim-status-client/blob/chore/macos-packaging-refactor/config.nims#L23), but nimbus-build-system was setting Nim parameters that caused dynamic linking regardless.

The changes in this PR result in those Nim parameters being set only if the OS is not Windows nor macOS, i.e. only if it's Linux.