### PR TITLE
new variable: QUICK_AND_DIRTY_COMPILER

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ Link PCRE, defaults to 1.
 
 `make LINK_PCRE=0`
 
+### QUICK_AND_DIRTY_COMPILER
+
+Skip multiple Nim compiler bootstrap iterations and tool building. Useful in
+CI. Defaults to 0.
+
+`make QUICK_AND_DIRTY_COMPILER=1 build-nim`
+
 ## Make targets
 
 ### build

--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -76,6 +76,7 @@ build-nim: | sanity-checks
 		CC=$(CC) \
 		MAKE="$(MAKE)" \
 		ARCH_OVERRIDE=$(ARCH_OVERRIDE) \
+		QUICK_AND_DIRTY_COMPILER=$(QUICK_AND_DIRTY_COMPILER) \
 		"$(CURDIR)/$(BUILD_SYSTEM_DIR)/scripts/build_nim.sh" "$(NIM_DIR)" ../Nim-csources ../nimble "$(CI_CACHE)"
 
 #- for each submodule, delete checked out files (that might prevent a fresh checkout); skip dotfiles

--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -112,3 +112,6 @@ CI_CACHE :=
 # bypassing the shipped Nim, usually for testing new Nim devel versions
 USE_SYSTEM_NIM := 0
 
+# Skip multiple bootstrap iterations and tool building.
+QUICK_AND_DIRTY_COMPILER := 0
+


### PR DESCRIPTION
Don't re-build the Nim compiler multiple times until we get identical binaries, like "build_all.sh" does. Don't build any tools either.

Disabled by default, useful in CI.

Makes Nim compiler building 2.6 times faster on my desktop.