### PR TITLE
Edit make update warning message 

### DIFF
--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -42,7 +42,7 @@ sanity-checks:
 warn-update:
 	if [[ -e $(UPDATE_TIMESTAMP) ]]; then \
 		if [[ $$(cat $(UPDATE_TIMESTAMP)) -ne $$($(GET_CURRENT_COMMIT_TIMESTAMP)) ]]; then \
-			echo -e "\n\"$$(basename "$(MAKE)") update\" was not executed for the current Git commit! The resulting build is unsupported.\n"; \
+			echo -e "\n\"$$(basename Warning: to ensure you are running Nimbus with a tested build, please always run "$(MAKE)") update\" after \"git pull\" (it looks like you've forgotten to do this). This also applies whenever you switch to a new branch or commit e.g. whenever you run \"git checkout\".\n"; \
 		fi; \
 	fi
 

--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -42,7 +42,7 @@ sanity-checks:
 warn-update:
 	if [[ -e $(UPDATE_TIMESTAMP) ]]; then \
 		if [[ $$(cat $(UPDATE_TIMESTAMP)) -ne $$($(GET_CURRENT_COMMIT_TIMESTAMP)) ]]; then \
-			echo -e "\n\"$$(basename Warning: to ensure you are running Nimbus with a tested build, please always run "$(MAKE)") update\" after \"git pull\" (it looks like you've forgotten to do this). This also applies whenever you switch to a new branch or commit e.g. whenever you run \"git checkout\".\n"; \
+			echo -e "\nWarning: to ensure you are building in a supported repo state, please always run \"$$(basename "$(MAKE)") update\" after \"git pull\" (it looks like you've forgotten to do this). This also applies whenever you switch to a new branch or commit, e.g.: whenever you run \"git checkout ...\".\n"; \
 		fi; \
 	fi
 

--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -42,7 +42,7 @@ sanity-checks:
 warn-update:
 	if [[ -e $(UPDATE_TIMESTAMP) ]]; then \
 		if [[ $$(cat $(UPDATE_TIMESTAMP)) -ne $$($(GET_CURRENT_COMMIT_TIMESTAMP)) ]]; then \
-			echo -e "\nWarning: to ensure you are building in a supported repo state, please always run \"$$(basename "$(MAKE)") update\" after \"git pull\" (it looks like you've forgotten to do this). This also applies whenever you switch to a new branch or commit, e.g.: whenever you run \"git checkout ...\".\n"; \
+			echo -e "\nWarning: to ensure you are building in a supported repo state, please always run \"$$(basename "$(MAKE)") update\" after \"git pull\"\n(it looks like you've forgotten to do this).\nThis also applies whenever you switch to a new branch or commit, e.g.: whenever you run \"git checkout ...\".\n"; \
 		fi; \
 	fi
 


### PR DESCRIPTION
**Rationale**
The most common error  (by far) will be forgetting to run `make update` after `git pull`. So we should make this explicit.

I don't naturally think of `git pull` as switching to a new commit (even though this is technically correct), i think of it as updating my software (not really in commit terms). This message is more consistent with this mental model.

A little long, but conciseness is less important than clarity.