### PR TITLE
NIM_COMMIT fix

### DIFF
--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -65,6 +65,7 @@ endif
 
 #- conditionally re-builds the Nim compiler (not usually needed, because `make update` calls this rule; delete $(NIM_BINARY) to force it)
 #- allows parallel building with the '+' prefix
+#- handles the case where NIM_COMMIT was previously used to build a non-default compiler
 #- forces a rebuild of csources, Nimble and a complete compiler rebuild, in case we're called after pulling a new Nim version
 #- uses our Git submodules for csources and Nimble (Git doesn't let us place them in another submodule)
 #- build_all.sh looks at the parent dir to decide whether to copy the resulting csources binary there,
@@ -73,7 +74,8 @@ endif
 #- macOS is also a special case, with its "ln" not supporting "-r"
 #- the AppVeyor 32-bit build is done on a 64-bit image, so we need to override the architecture detection with ARCH_OVERRIDE
 build-nim: | sanity-checks
-	+ NIM_BUILD_MSG="$(BUILD_MSG) Nim compiler" \
+	+ if [[ -z "$(NIM_COMMIT)" ]]; then git submodule update --init --recursive "$(BUILD_SYSTEM_DIR)"; fi; \
+		NIM_BUILD_MSG="$(BUILD_MSG) Nim compiler" \
 		V=$(V) \
 		CC=$(CC) \
 		MAKE="$(MAKE)" \


### PR DESCRIPTION
Scenario:

```text
make NIM_COMMIT=version-1-6 build-nim
./env.sh nim --version
# great, you got the compiler version you wanted
make build-nim
./env.sh nim --version
# what do you mean it's the same?
```

The recently simplified NIM_COMMIT handling just left alone the "vendor/nimbus-build-system/vendor/Nim" submodule, when the var was empty, but that's not what we want when we try to get back to the default compiler version after experimenting with upstream branches.

The fix is to run "git submodule update ..." on that compiler submodule and bring it back to the default commit.