### PR TITLE
EXCLUDED_NIM_PACKAGES

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,33 @@ You also need to specify it when using this non-default Nim compiler version:
 
 `make -j8 NIM_COMMIT="v1.2.6" nimbus_beacon_node`
 
+### EXCLUDED_NIM_PACKAGES
+
+List of relative paths (incomplete ones also work) to Git submodules that
+should not end up as Nim packages in "vendor/.nimble" - usually because they
+duplicate more high-level ones.
+
+For example, say we have:
+
+```text
+$ find vendor -name "nim-chronos" | sort
+vendor/nim-chronos
+vendor/nim-waku/vendor/nim-chronos
+vendor/nim-waku/vendor/nim-dnsdisc/vendor/nim-chronos
+```
+
+We only want the top-level "vendor/nim-chronos", so we put the rest in
+`EXCLUDED_NIM_PACKAGES`, in the top-level Makefile:
+
+```text
+EXCLUDED_NIM_PACKAGES := vendor/nim-waku/vendor/nim-chronos \
+			 vendor/nim-waku/vendor/nimbus-build-system \
+			 vendor/nim-waku/vendor/nim-dnsdisc/vendor
+```
+
+As you see, we can exclude all those "nim-dnsdisc" submodules with a single
+line, because the pattern is not anchored during the match.
+
 ## Make targets
 
 ### build

--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -141,7 +141,7 @@ endif
 #  for runtime path (i.e.: the second line in $(NIMBLE_DIR)/pkgs/*/*.nimble-link)
 $(NIMBLE_DIR):
 	mkdir -p $(NIMBLE_DIR)/pkgs
-	NIMBLE_DIR="$(CURDIR)/$(NIMBLE_DIR)" PWD_CMD="$(PWD)" \
+	NIMBLE_DIR="$(CURDIR)/$(NIMBLE_DIR)" PWD_CMD="$(PWD)" EXCLUDED_NIM_PACKAGES="$(EXCLUDED_NIM_PACKAGES)" \
 		git submodule foreach --recursive --quiet '$(CURDIR)/$(BUILD_SYSTEM_DIR)/scripts/create_nimble_link.sh "$$sm_path"'
 
 clean-cross:

--- a/scripts/create_nimble_link.sh
+++ b/scripts/create_nimble_link.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2018-2019 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2018-2021 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license
@@ -11,12 +11,27 @@ set -u
 
 module_name="${1#*/}"
 
-if [ `ls -1 *.nimble 2>/dev/null | wc -l ` -gt 0 ]; then
-  mkdir -p "${NIMBLE_DIR}/pkgs/${module_name}-#head"
+if [[ $(ls -1 *.nimble 2>/dev/null | wc -l) -gt 0 ]]; then
   PKG_DIR="$(${PWD_CMD})"
-  if [ -d src ]; then
+  for EXCLUDED_REL_PATH in ${EXCLUDED_NIM_PACKAGES}; do
+    if [[ "${PKG_DIR}" =~ ${EXCLUDED_REL_PATH} ]]; then
+      # skip it
+      exit
+    fi
+  done
+
+  if [[ -d src ]]; then
     PKG_DIR="${PKG_DIR}/src"
   fi
-  echo -e "${PKG_DIR}\n${PKG_DIR}" > "${NIMBLE_DIR}/pkgs/${module_name}-#head/${module_name}.nimble-link"
+  mkdir -p "${NIMBLE_DIR}/pkgs/${module_name}-#head"
+
+  NIMBLE_LINK_PATH="${NIMBLE_DIR}/pkgs/${module_name}-#head/${module_name}.nimble-link"
+  if [[ -e "${NIMBLE_LINK_PATH}" ]]; then
+    echo -e "\nERROR: Nim package already present in '${NIMBLE_LINK_PATH}': '$(head -n1 "${NIMBLE_LINK_PATH}")'"
+    echo -e "Will not replace it with '${PKG_DIR}'.\nPick one and put the other's relative path in EXCLUDED_NIM_PACKAGES.\nSee also: https://github.com/status-im/nimbus-build-system#excluded_nim_packages\n"
+    rm -rf "${NIMBLE_DIR}"
+    exit 1
+  fi
+  echo -e "${PKG_DIR}\n${PKG_DIR}" > "${NIMBLE_LINK_PATH}"
 fi
 


### PR DESCRIPTION
This is a solution for the problem described here: https://github.com/status-im/nim-chronos/issues/255#issuecomment-1016209014

(multiple Git submodules pointing at the same repo, but at different versions, and the need to pick one of them as a Nim package)