### PR TITLE
build_nim.sh: limit the number of Nim binaries

### DIFF
--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -49,6 +49,7 @@ else
 fi
 
 NIM_BINARY="${NIM_DIR}/bin/nim${EXE_SUFFIX}"
+MAX_NIM_BINARIES="10" # Old ones get deleted.
 
 nim_needs_rebuilding() {
 	REBUILD=0
@@ -88,6 +89,13 @@ nim_needs_rebuilding() {
 	if [[ -n "$CI_CACHE" && -d "$CI_CACHE" ]]; then
 		cp -a "$CI_CACHE"/* "$NIM_DIR"/bin/ || true # let this one fail with an empty cache dir
 	fi
+
+	# Delete old Nim binaries, to put a limit on how much storage we use.
+	for F in "$(ls -t "${NIM_DIR}"/bin/nim_commit_* | tail -n +$((MAX_NIM_BINARIES + 1)))"; do
+		if [[ -e "${F}" ]]; then
+			rm "${F}"
+		fi
+	done
 
 	# Compare the last built commit to the one requested.
 	# Handle the scenario where our symlink is manually deleted by the user.


### PR DESCRIPTION
The most recent 10 compiler binaries should be enough for everyone.