### PR TITLE
allow overriding CC with clang or other

### DIFF
--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -7,7 +7,7 @@
 
 SHELL := bash # the shell used internally by "make"
 
-CC := gcc
+CC ?= gcc
 LD := $(CC)
 
 #- extra parameters for the Nim compiler


### PR DESCRIPTION
Otherwise sanity checks fail due to lack of GCC on MacOS.

~~This might break things horribly, so I will test in other projects first:~~
This appears to not break anything obvious in all the following projects:

* https://github.com/status-im/nwaku/pull/1223 - Works.
* https://github.com/status-im/nimbus-eth2/pull/4215 - Works.
* ~~https://github.com/status-im/status-desktop/pull/7740~~ - [Can't test due to very old version used.](https://github.com/status-im/status-desktop/pull/7740#issuecomment-1267073235)