### PR TITLE
hardcode CC to gcc for windows

### DIFF
--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -7,7 +7,12 @@
 
 SHELL := bash # the shell used internally by "make"
 
+# Windows does not symlink cc to gcc
+ifeq ($(OS), Windows_NT)
+CC := gcc
+else
 CC ?= gcc
+endif
 LD := $(CC)
 
 #- extra parameters for the Nim compiler


### PR DESCRIPTION
Windows doesn't have a `cc` symlnk and this results in build failure:
```
C compiler (cc) not installed. Aborting.
```
Because `?=` operator treats `CC` as already set, since it defaults to `cc`:
https://www.gnu.org/software/make/manual/make.html#Implicit-Variables

Related to:

* https://github.com/status-im/nimbus-build-system/pull/51