### PR TITLE
Fix windows CI building

### DIFF
--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -261,7 +261,7 @@ build_nim() {
 	if [[ -n "$CI_CACHE" ]]; then
 		rm -rf "$CI_CACHE"
 		mkdir "$CI_CACHE"
-		cp -a "$NIM_DIR"/bin/* "$CI_CACHE"/
+		cp "$NIM_DIR"/bin/* "$CI_CACHE"/
 	fi
 }
 

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -8,7 +8,7 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-set -xe
+set -e
 
 # Git commits
 : ${CSOURCES_V1_COMMIT:=a8a5241f9475099c823cfe1a5e0ca4022ac201ff}
@@ -256,8 +256,6 @@ build_nim() {
 
 	# update the CI cache
 	popd # we were in $NIM_DIR
-
-	ls "$NIM_DIR"/bin/*
 	if [[ -n "$CI_CACHE" ]]; then
 		rm -rf "$CI_CACHE"
 		mkdir "$CI_CACHE"

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -8,7 +8,7 @@
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
 
-set -e
+set -xe
 
 # Git commits
 : ${CSOURCES_V1_COMMIT:=a8a5241f9475099c823cfe1a5e0ca4022ac201ff}
@@ -256,6 +256,8 @@ build_nim() {
 
 	# update the CI cache
 	popd # we were in $NIM_DIR
+
+	ls "$NIM_DIR"/bin/*
 	if [[ -n "$CI_CACHE" ]]; then
 		rm -rf "$CI_CACHE"
 		mkdir "$CI_CACHE"


### PR DESCRIPTION
Recent github action runner bump causes `build_nim.sh` to fail. Fix here thanks to @markspanbroek 
An alternative is https://github.com/status-im/nim-codex/pull/328/commits/6da53365f26ac30126f319638409dea07b5e2318