### PR TITLE
Fix checking out of recent Nim tags in shallow repo

### DIFF
--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -74,7 +74,7 @@ nim_needs_rebuilding() {
 			# Pay the price for a non-default NIM_COMMIT here, by fetching everything.
 			# (This includes upstream branches and tags that might be missing from our fork.)
 			git remote add upstream https://github.com/nim-lang/Nim
-			git fetch --all
+			git fetch --all --tags --quiet || true
 			git checkout -q ${NIM_COMMIT}
 		fi
 		# In case the local branch diverged and a fast-forward merge is not possible.

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -74,7 +74,7 @@ nim_needs_rebuilding() {
 			# Pay the price for a non-default NIM_COMMIT here, by fetching everything.
 			# (This includes upstream branches and tags that might be missing from our fork.)
 			git remote add upstream https://github.com/nim-lang/Nim
-			git fetch --all --tags --quiet || true
+			git fetch --all --tags --quiet
 			git checkout -q ${NIM_COMMIT}
 		fi
 		# In case the local branch diverged and a fast-forward merge is not possible.


### PR DESCRIPTION
When calling `git fetch` on a shallow repo, recent tags or commits are refused. Fetching with `--tags` ensures that the latest tags and the commits that they point to are fetched.

More info:
https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---update-shallow