### PR TITLE
Use upstream build system when possible

### DIFF
--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -130,7 +130,7 @@ build_nim() {
 	if grep -q skipIntegrityCheck koch.nim; then
 		# Run Nim buildchain
 		. ci/funs.sh
-		nimBuildCsourcesIfNeeded
+		nimBuildCsourcesIfNeeded $UCPU
 		bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --warnings:off --hints:off koch
 		./koch --skipIntegrityCheck boot -d:release --skipUserCfg --skipParentCfg --warnings:off --hints:off
 		if [[ "${QUICK_AND_DIRTY_COMPILER}" == "0" ]]; then

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -130,7 +130,7 @@ build_nim() {
 	if grep -q skipIntegrityCheck koch.nim; then
 		# Run Nim buildchain
 		. ci/funs.sh
-		NCPU=1 nimBuildCsourcesIfNeeded $UCPU
+		NIMCORES=1 nimBuildCsourcesIfNeeded $UCPU
 		bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --warnings:off --hints:off koch
 		./koch --skipIntegrityCheck boot -d:release --skipUserCfg --skipParentCfg --warnings:off --hints:off
 		if [[ "${QUICK_AND_DIRTY_COMPILER}" == "0" ]]; then

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -130,7 +130,7 @@ build_nim() {
 	if grep -q skipIntegrityCheck koch.nim; then
 		# Run Nim buildchain
 		. ci/funs.sh
-		nimBuildCsourcesIfNeeded $UCPU
+		NCPU=1 nimBuildCsourcesIfNeeded $UCPU
 		bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --warnings:off --hints:off koch
 		./koch --skipIntegrityCheck boot -d:release --skipUserCfg --skipParentCfg --warnings:off --hints:off
 		if [[ "${QUICK_AND_DIRTY_COMPILER}" == "0" ]]; then

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -142,6 +142,9 @@ build_nim() {
 		fi
 	else
 		# Custom buildchain for older versions
+		# TODO Remove this once the default NIM_COMMIT supports `--skipIntegrityCheck`
+		# We will still be able to compile older versions by removing the flag,
+		# which will just waste a bit of CPU
 
 		# Git repos for csources and Nimble
 		if [[ ! -d "$CSOURCES_DIR" ]]; then

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -127,124 +127,141 @@ build_nim() {
 	# working directory
 	pushd "$NIM_DIR"
 
-	# Git repos for csources and Nimble
-	if [[ ! -d "$CSOURCES_DIR" ]]; then
-		if git merge-base --is-ancestor $CSOURCES_V2_START_COMMIT $NIM_COMMIT_HASH; then
-		  CSOURCES_REPO=$CSOURCES_V2_REPO
-		  CSOURCES_COMMIT=$CSOURCES_V2_COMMIT
+	if grep -q skipIntegrityCheck koch.nim; then
+		# Run Nim buildchain
+		. ci/funs.sh
+		nimBuildCsourcesIfNeeded
+		bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --warnings:off --hints:off koch
+		./koch --skipIntegrityCheck boot -d:release --skipUserCfg --skipParentCfg --warnings:off --hints:off
+		if [[ "${QUICK_AND_DIRTY_COMPILER}" == "0" ]]; then
+			# We want tools
+			./koch tools -d:release --skipUserCfg --skipParentCfg --warnings:off --hints:off
+		elif [[ "${QUICK_AND_DIRTY_NIMBLE}" != "0" ]]; then
+			# We just want nimble
+			./koch nimble -d:release --skipUserCfg --skipParentCfg --warnings:off --hints:off
+		fi
+	else
+		# Custom buildchain for older versions
+
+		# Git repos for csources and Nimble
+		if [[ ! -d "$CSOURCES_DIR" ]]; then
+			if git merge-base --is-ancestor $CSOURCES_V2_START_COMMIT $NIM_COMMIT_HASH; then
+			  CSOURCES_REPO=$CSOURCES_V2_REPO
+			  CSOURCES_COMMIT=$CSOURCES_V2_COMMIT
+			else
+			  CSOURCES_REPO=$CSOURCES_V1_REPO
+			  CSOURCES_COMMIT=$CSOURCES_V1_COMMIT
+			fi
+
+			mkdir -p "$CSOURCES_DIR"
+			pushd "$CSOURCES_DIR"
+			git clone $CSOURCES_REPO .
+			git checkout $CSOURCES_COMMIT
+			popd
+		fi
+		if [[ "$CSOURCES_DIR" != "csources" ]]; then
+			rm -rf csources
+			ln -s "$CSOURCES_DIR" csources
+		fi
+
+		if [[ ! -d "$NIMBLE_DIR" ]]; then
+			mkdir -p "$NIMBLE_DIR"
+			pushd "$NIMBLE_DIR"
+			git clone https://github.com/nim-lang/nimble.git .
+			git checkout $NIMBLE_COMMIT
+			# we have to delete .git or koch.nim will checkout a branch tip, overriding our target commit
+			rm -rf .git
+			popd
+		fi
+		if [[ "$NIMBLE_DIR" != "dist/nimble" ]]; then
+			mkdir -p dist
+			rm -rf dist/nimble
+			ln -s ../"$NIMBLE_DIR" dist/nimble
+		fi
+
+		# bootstrap the Nim compiler and build the tools
+		rm -f bin/{nim,nim_csources}
+		pushd csources
+		if [[ "$ON_WINDOWS" == "0" ]]; then
+			$MAKE $UCPU clean
+			$MAKE $UCPU LD=$CC
 		else
-		  CSOURCES_REPO=$CSOURCES_V1_REPO
-		  CSOURCES_COMMIT=$CSOURCES_V1_COMMIT
+			$MAKE myos=windows $UCPU clean
+			$MAKE myos=windows $UCPU CC=gcc LD=gcc
+		fi
+		popd
+		if [[ -e csources/bin ]]; then
+			rm -f bin/nim bin/nim_csources
+			cp -a csources/bin/nim bin/nim
+			cp -a csources/bin/nim bin/nim_csources
+			rm -rf csources/bin
+		else
+			cp -a bin/nim bin/nim_csources
+		fi
+		if [[ "$QUICK_AND_DIRTY_COMPILER" == "0" ]]; then
+			sed \
+				-e 's/koch$/--warnings:off --hints:off koch/' \
+				-e 's/koch boot/koch boot --warnings:off --hints:off/' \
+				-e '/nimBuildCsourcesIfNeeded/d' \
+				build_all.sh > build_all_custom.sh
+			sh build_all_custom.sh
+			rm build_all_custom.sh
+		else
+			# Don't re-build it multiple times until we get identical
+			# binaries, like "build_all.sh" does. Don't build any tools
+			# either. This is all about build speed, not developer comfort.
+			bin/nim_csources \
+				c \
+				--compileOnly \
+				--nimcache:nimcache \
+				-d:release \
+				--skipUserCfg \
+				--skipParentCfg \
+				--warnings:off \
+				--hints:off \
+				compiler/nim.nim
+			bin/nim_csources \
+				jsonscript \
+				--nimcache:nimcache \
+				--skipUserCfg \
+				--skipParentCfg \
+				compiler/nim.nim
+			cp -a compiler/nim bin/nim1
+			# If we stop here, we risk ending up with a buggy compiler:
+			# https://github.com/status-im/nimbus-eth2/pull/2220
+			# https://github.com/status-im/nimbus-eth2/issues/2310
+			bin/nim1 \
+				c \
+				--compileOnly \
+				--nimcache:nimcache \
+				-d:release \
+				--skipUserCfg \
+				--skipParentCfg \
+				--warnings:off \
+				--hints:off \
+				compiler/nim.nim
+			bin/nim1 \
+				jsonscript \
+				--nimcache:nimcache \
+				--skipUserCfg \
+				--skipParentCfg \
+				compiler/nim.nim
+			rm -f bin/nim
+			cp -a compiler/nim bin/nim
+			rm bin/nim1
+
+			# Do we want Nimble in this quick build?
+			if [[ "${QUICK_AND_DIRTY_NIMBLE}" != "0" ]]; then
+				bin/nim c -d:release --noNimblePath --skipUserCfg --skipParentCfg dist/nimble/src/nimble.nim
+				mv dist/nimble/src/nimble bin/
+			fi
 		fi
 
-		mkdir -p "$CSOURCES_DIR"
-		pushd "$CSOURCES_DIR"
-		git clone $CSOURCES_REPO .
-		git checkout $CSOURCES_COMMIT
-		popd
-	fi
-	if [[ "$CSOURCES_DIR" != "csources" ]]; then
-		rm -rf csources
-		ln -s "$CSOURCES_DIR" csources
-	fi
-
-	if [[ ! -d "$NIMBLE_DIR" ]]; then
-		mkdir -p "$NIMBLE_DIR"
-		pushd "$NIMBLE_DIR"
-		git clone https://github.com/nim-lang/nimble.git .
-		git checkout $NIMBLE_COMMIT
-		# we have to delete .git or koch.nim will checkout a branch tip, overriding our target commit
-		rm -rf .git
-		popd
-	fi
-	if [[ "$NIMBLE_DIR" != "dist/nimble" ]]; then
-		mkdir -p dist
-		rm -rf dist/nimble
-		ln -s ../"$NIMBLE_DIR" dist/nimble
-	fi
-
-	# bootstrap the Nim compiler and build the tools
-	rm -f bin/{nim,nim_csources}
-	pushd csources
-	if [[ "$ON_WINDOWS" == "0" ]]; then
-		$MAKE $UCPU clean
-		$MAKE $UCPU LD=$CC
-	else
-		$MAKE myos=windows $UCPU clean
-		$MAKE myos=windows $UCPU CC=gcc LD=gcc
-	fi
-	popd
-	if [[ -e csources/bin ]]; then
-		rm -f bin/nim bin/nim_csources
-		cp -a csources/bin/nim bin/nim
-		cp -a csources/bin/nim bin/nim_csources
-		rm -rf csources/bin
-	else
-		cp -a bin/nim bin/nim_csources
-	fi
-	if [[ "$QUICK_AND_DIRTY_COMPILER" == "0" ]]; then
-		sed \
-			-e 's/koch$/--warnings:off --hints:off koch/' \
-			-e 's/koch boot/koch boot --warnings:off --hints:off/' \
-			-e '/nimBuildCsourcesIfNeeded/d' \
-			build_all.sh > build_all_custom.sh
-		sh build_all_custom.sh
-		rm build_all_custom.sh
-	else
-		# Don't re-build it multiple times until we get identical
-		# binaries, like "build_all.sh" does. Don't build any tools
-		# either. This is all about build speed, not developer comfort.
-		bin/nim_csources \
-			c \
-			--compileOnly \
-			--nimcache:nimcache \
-			-d:release \
-			--skipUserCfg \
-			--skipParentCfg \
-			--warnings:off \
-			--hints:off \
-			compiler/nim.nim
-		bin/nim_csources \
-			jsonscript \
-			--nimcache:nimcache \
-			--skipUserCfg \
-			--skipParentCfg \
-			compiler/nim.nim
-		cp -a compiler/nim bin/nim1
-		# If we stop here, we risk ending up with a buggy compiler:
-		# https://github.com/status-im/nimbus-eth2/pull/2220
-		# https://github.com/status-im/nimbus-eth2/issues/2310
-		bin/nim1 \
-			c \
-			--compileOnly \
-			--nimcache:nimcache \
-			-d:release \
-			--skipUserCfg \
-			--skipParentCfg \
-			--warnings:off \
-			--hints:off \
-			compiler/nim.nim
-		bin/nim1 \
-			jsonscript \
-			--nimcache:nimcache \
-			--skipUserCfg \
-			--skipParentCfg \
-			compiler/nim.nim
-		rm -f bin/nim
-		cp -a compiler/nim bin/nim
-		rm bin/nim1
-
-		# Do we want Nimble in this quick build?
-		if [[ "${QUICK_AND_DIRTY_NIMBLE}" != "0" ]]; then
-			bin/nim c -d:release --noNimblePath --skipUserCfg --skipParentCfg dist/nimble/src/nimble.nim
-			mv dist/nimble/src/nimble bin/
+		if [[ "$QUICK_AND_DIRTY_COMPILER" == "0" || "${QUICK_AND_DIRTY_NIMBLE}" != "0" ]]; then
+			# Nimble needs a CA cert
+			rm -f bin/cacert.pem
+			curl -LsS -o bin/cacert.pem https://curl.se/ca/cacert.pem || echo "Warning: 'curl' failed to download a CA cert needed by Nimble. Ignoring it."
 		fi
-	fi
-
-	if [[ "$QUICK_AND_DIRTY_COMPILER" == "0" || "${QUICK_AND_DIRTY_NIMBLE}" != "0" ]]; then
-		# Nimble needs a CA cert
-		rm -f bin/cacert.pem
-		curl -LsS -o bin/cacert.pem https://curl.se/ca/cacert.pem || echo "Warning: 'curl' failed to download a CA cert needed by Nimble. Ignoring it."
 	fi
 
 	# record the built commit


### PR DESCRIPTION
Since https://github.com/nim-lang/Nim/pull/21795, upstream lets us build the compiler only two times instead of three

Speed comparison:
|  | Upstream | NBS |
| -------- | -------- | -------- |
| Default (real)     | 3m45.629s     | 4m12.021s     |
| Default (user)     | 15m54.332s     | 14m36.437s     |
| Quick & Dirty (real) | 2m12.974s  | 3m1.052s |
| Quick & Dirty (user) | 9m27.531s  | 9m3.201s |

Note that currently, upstream always uses all the cores: https://github.com/nim-lang/Nim/pull/21823 (EDIT: not anymore, was merged)
Since the current version cannot compile devel, it's hard to compare speed apples-to-apples, but the `user` time seems in the same ballpark (especially since it now needs to clone a new repo)

PS: for review, [hiding whitespaces](https://github.com/status-im/nimbus-build-system/pull/61/files?diff=split&w=1) is your friend