### PR TITLE
install Nimble CA cert when `skipIntegrityCheck`

### DIFF
--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -259,12 +259,12 @@ build_nim() {
 				mv dist/nimble/src/nimble bin/
 			fi
 		fi
+	fi
 
-		if [[ "$QUICK_AND_DIRTY_COMPILER" == "0" || "${QUICK_AND_DIRTY_NIMBLE}" != "0" ]]; then
-			# Nimble needs a CA cert
-			rm -f bin/cacert.pem
-			curl -LsS -o bin/cacert.pem https://curl.se/ca/cacert.pem || echo "Warning: 'curl' failed to download a CA cert needed by Nimble. Ignoring it."
-		fi
+	if [[ "$QUICK_AND_DIRTY_COMPILER" == "0" || "${QUICK_AND_DIRTY_NIMBLE}" != "0" ]]; then
+		# Nimble needs a CA cert
+		rm -f bin/cacert.pem
+		curl -LsS -o bin/cacert.pem https://curl.se/ca/cacert.pem || echo "Warning: 'curl' failed to download a CA cert needed by Nimble. Ignoring it."
 	fi
 
 	# record the built commit


### PR DESCRIPTION
In #61 a regression was introduced where Nimble fails to build packages.

```
    Prompt: No local packages.json found, download it from internet? -> [forced yes]
Downloading Official package list
       Tip: 6 messages have been suppressed, use --verbose to show them.
     Error: Refresh failed
        ... Could not download: No SSL/TLS CA certificates found.
Error: Process completed with exit code 1.
```

Ensure that CA cert is being downloaded once more, even when `koch` supports `skipIntegrityCheck`.