### PR TITLE
Fix time-stamping to work with GPG signed commits

### DIFF
--- a/makefiles/variables.mk
+++ b/makefiles/variables.mk
@@ -96,7 +96,7 @@ else
   NPROC_CMD := nproc
 endif
 
-GET_CURRENT_COMMIT_TIMESTAMP := git log --pretty=format:%cd -n 1 $(GIT_TIMESTAMP_ARG)
+GET_CURRENT_COMMIT_TIMESTAMP := git log --no-show-signature --pretty=format:%cd -n 1 $(GIT_TIMESTAMP_ARG)
 UPDATE_TIMESTAMP := .update.timestamp
 
 ifeq ($(BUILD_SYSTEM_DIR),)


### PR DESCRIPTION
If `HEAD` is pointing to a gpg-signed commit, the result of the previous `GET_CURRENT_COMMIT_TIMESTAMP` expression will include GPG info, which in turn will end up in `.update.timestamp` for the current project. This is especially relevant if the user has configured `git config log.showSignature true`.

Fix this behavior by ignoring irrelevant GPG signed status with `--no-show-signature`.