### PR TITLE
Allow passing config to submodule initialization in `update-common`

### DIFF
--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -105,11 +105,11 @@ update-test:
 #- rebuilds the Nim compiler if the corresponding submodule is updated
 update-common: | sanity-checks update-test
 	git submodule foreach --quiet 'git ls-files --exclude-standard --recurse-submodules -z -- ":!:.*" | xargs -0 rm -rf'
-	git submodule update --init --recursive || true
+	git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive || true
 	# changing URLs in a submodule's submodule means we have to sync and update twice
 	git submodule sync --quiet --recursive
-	git submodule update --init --recursive
-	git submodule foreach --quiet --recursive 'git reset --quiet --hard'
+	git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive
+	git submodule foreach --quiet --recursive 'git $(GIT_SUBMODULE_CONFIG) reset --quiet --hard'
 	find . -type d -name nimcache -print0 | xargs -0 rm -rf
 	$(GET_CURRENT_COMMIT_TIMESTAMP) > $(UPDATE_TIMESTAMP)
 	rm -rf $(NIMBLE_DIR)
@@ -255,4 +255,3 @@ fetch-dlls: | build
 		cp -a $(ROCKSDB_DIR)/*.dll . && \
 		$(UNZIP) dlls.zip
 endif
-


### PR DESCRIPTION
To configure submodule specific config overrides, allow passing `$(GIT_SUBMODULE_CONFIG)` to `update-common`. Use case for `nimbus-eth2` is to exclude a large file that we don't need from LFS checkout.