### PR TITLE
Feature: configurable Nim upstream repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ use a fork from somewhere else, you can set this to the repo's URL.
 As before, you will need to specify this again when using this non-default Nim
 compiler version:
 
-`make -j8 NIM_COMMIT="4561f01" NIM_COMMIT_REPO="https://github.com/myorg/my-nim-fork" nimbus_beacon_node`
+`make -j8 NIM_COMMIT="4561f01" NIM_REPO="https://github.com/myorg/my-nim-fork" nimbus_beacon_node`
 
 ### EXCLUDED_NIM_PACKAGES
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ You also need to specify it when using this non-default Nim compiler version:
 
 `make -j8 NIM_COMMIT="v1.2.6" nimbus_beacon_node`
 
-### NIM_REPO
+### NIM_COMMIT_REPO
 
 `NIM_COMMIT` will try to fetch commits from the 
 [status-im fork](https://github.com/status-im/Nim), followed by the
@@ -181,7 +181,7 @@ use a fork from somewhere else, you can set this to the repo's URL.
 As before, you will need to specify this again when using this non-default Nim
 compiler version:
 
-`make -j8 NIM_COMMIT="4561f01" NIM_REPO="https://github.com/myorg/my-nim-fork" nimbus_beacon_node`
+`make -j8 NIM_COMMIT="4561f01" NIM_COMMIT_REPO="https://github.com/myorg/my-nim-fork" nimbus_beacon_node`
 
 ### EXCLUDED_NIM_PACKAGES
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ You also need to specify it when using this non-default Nim compiler version:
 
 `make -j8 NIM_COMMIT="v1.2.6" nimbus_beacon_node`
 
+### NIM_REPO
+
+`NIM_COMMIT` will try to fetch commits from the 
+[status-im fork](https://github.com/status-im/Nim), followed by the
+[official Nim language repo](https://github.com/nim-lang/Nim). If you want to
+use a fork from somewhere else, you can set this to the repo's URL.
+
+`make -j8 NIM_COMMIT="4561f01" NIM_COMMIT_REPO="https://github.com/myorg/my-nim-fork"`
+
+As before, you will need to specify this again when using this non-default Nim
+compiler version:
+
+`make -j8 NIM_COMMIT="4561f01" NIM_COMMIT_REPO="https://github.com/myorg/my-nim-fork" nimbus_beacon_node`
+
 ### EXCLUDED_NIM_PACKAGES
 
 List of relative paths (incomplete ones also work) to Git submodules that

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -66,8 +66,12 @@ nim_needs_rebuilding() {
 		if ! git checkout -q ${NIM_COMMIT} 2>/dev/null; then
 			# Pay the price for a non-default NIM_COMMIT here, by fetching everything.
 			# (This includes upstream branches and tags that might be missing from our fork.)
-			git remote remove upstream 2>/dev/null || true
-			git remote add upstream "${NIM_COMMIT_REPO_URL}"
+			NEW_REMOTE="upstream"
+			if git remote | grep -q "^upstream$"; then
+				# upstream already exists, call it "extra"
+				NEW_REMOTE="extra"
+			fi
+			git remote add "${NEW_REMOTE}" "${NIM_COMMIT_REPO_URL}"
 			git fetch --all --tags --quiet
 			git checkout -q ${NIM_COMMIT}
 		fi

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -66,6 +66,7 @@ nim_needs_rebuilding() {
 		if ! git checkout -q ${NIM_COMMIT} 2>/dev/null; then
 			# Pay the price for a non-default NIM_COMMIT here, by fetching everything.
 			# (This includes upstream branches and tags that might be missing from our fork.)
+			git remote remove upstream 2>/dev/null || true
 			git remote add upstream "${NIM_REPO_URL}"
 			git fetch --all --tags --quiet
 			git checkout -q ${NIM_COMMIT}

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -70,6 +70,7 @@ nim_needs_rebuilding() {
 			if git remote | grep -q "^upstream$"; then
 				# upstream already exists, call it "extra"
 				NEW_REMOTE="extra"
+				git remote remove extra 2>/dev/null || true
 			fi
 			git remote add "${NEW_REMOTE}" "${NIM_COMMIT_REPO_URL}"
 			git fetch --all --tags --quiet

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -13,7 +13,7 @@ set -e
 # NIM_COMMIT could be a (partial) commit hash, a tag, a branch name, etc. Empty by default.
 NIM_COMMIT_HASH="" # full hash for NIM_COMMIT, retrieved in "nim_needs_rebuilding()"
 # The actual repository we clone from when specifying a commit hash.
-NIM_REPO_URL="${NIM_REPO:-'https://github.com/nim-lang/Nim'}"
+NIM_REPO_URL="${NIM_REPO:-https://github.com/nim-lang/Nim}"
 
 # script arguments
 [[ $# -ne 4 ]] && { echo "Usage: $0 nim_dir csources_dir nimble_dir ci_cache_dir"; exit 1; }

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -12,6 +12,8 @@ set -e
 
 # NIM_COMMIT could be a (partial) commit hash, a tag, a branch name, etc. Empty by default.
 NIM_COMMIT_HASH="" # full hash for NIM_COMMIT, retrieved in "nim_needs_rebuilding()"
+# The actual repository we clone from when specifying a commit hash.
+NIM_REPO_URL="${NIM_REPO:-'https://github.com/nim-lang/Nim'}"
 
 # script arguments
 [[ $# -ne 4 ]] && { echo "Usage: $0 nim_dir csources_dir nimble_dir ci_cache_dir"; exit 1; }
@@ -64,7 +66,7 @@ nim_needs_rebuilding() {
 		if ! git checkout -q ${NIM_COMMIT} 2>/dev/null; then
 			# Pay the price for a non-default NIM_COMMIT here, by fetching everything.
 			# (This includes upstream branches and tags that might be missing from our fork.)
-			git remote add upstream https://github.com/nim-lang/Nim
+			git remote add upstream "${NIM_REPO_URL}"
 			git fetch --all --tags --quiet
 			git checkout -q ${NIM_COMMIT}
 		fi

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -13,7 +13,7 @@ set -e
 # NIM_COMMIT could be a (partial) commit hash, a tag, a branch name, etc. Empty by default.
 NIM_COMMIT_HASH="" # full hash for NIM_COMMIT, retrieved in "nim_needs_rebuilding()"
 # The actual repository we clone from when specifying a commit hash.
-NIM_REPO_URL="${NIM_REPO:-https://github.com/nim-lang/Nim}"
+NIM_COMMIT_REPO_URL="${NIM_COMMIT_REPO:-https://github.com/nim-lang/Nim}"
 
 # script arguments
 [[ $# -ne 4 ]] && { echo "Usage: $0 nim_dir csources_dir nimble_dir ci_cache_dir"; exit 1; }
@@ -67,7 +67,7 @@ nim_needs_rebuilding() {
 			# Pay the price for a non-default NIM_COMMIT here, by fetching everything.
 			# (This includes upstream branches and tags that might be missing from our fork.)
 			git remote remove upstream 2>/dev/null || true
-			git remote add upstream "${NIM_REPO_URL}"
+			git remote add upstream "${NIM_COMMIT_REPO_URL}"
 			git fetch --all --tags --quiet
 			git checkout -q ${NIM_COMMIT}
 		fi


### PR DESCRIPTION
Hi guys, not sure if this is a feature that interests anyone else but, since I needed it and implemented it, I've decided to put out a PR here. 

It adds a way to specify a different upstream repo for the Nim compiler (i.e. you can set `NIM_REPO=https://github.com/my-org/Nim`), in case  you want to build it from a fork. Feel free to kill it if not interesting, I'm otherwise happy to fix it if it has issues.