### PR TITLE
fix miniupnpc build on Windows by not escaping PATH

### DIFF
--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -132,7 +132,7 @@ nat-libs: | libminiupnpc.a libnatpmp.a
 libminiupnpc.a: | sanity-checks
 ifeq ($(OS), Windows_NT)
 	+ [ -e vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc/$@ ] || \
-		PATH=".:${PATH}" "$(MAKE)" -C vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc -f Makefile.mingw CC=$(CC) $@ $(HANDLE_OUTPUT)
+		PATH=".;$${PATH}" "$(MAKE)" -C vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc -f Makefile.mingw CC=$(CC) $@ $(HANDLE_OUTPUT)
 else
 	+ "$(MAKE)" -C vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc build/$@ $(HANDLE_OUTPUT)
 endif


### PR DESCRIPTION
Also use correct `;` divider. Otherwise the build fails with:
```
nimbus@windows-01 MINGW64 /d/beacon-node-holesky-libp2p/repo (nim-libp2p-auto-bump-unstable)
$ make libminiupnpc.a --debug
Reading makefiles...
Updating makefiles....
Updating goal targets....
 File 'libminiupnpc.a' does not exist.
   File 'sanity-checks' does not exist.
  Must remake target 'sanity-checks'.
  Successfully remade target file 'sanity-checks'.
Must remake target 'libminiupnpc.a'.
process_begin: CreateProcess(NULL, git rev-parse --short HEAD, ...) failed.
Makefile.mingw:56: pipe: No error
gcc: fatal error: cannot execute 'cc1': CreateProcess: No such file or directory
compilation terminated.
make[1]: *** [Makefile.mingw:121: wingenminiupnpcstrings.exe] Error 1
make: *** [vendor/nimbus-build-system/makefiles/targets.mk:134: libminiupnpc.a] Error 2
```
Resolves:
* https://github.com/status-im/nimbus-eth2/issues/5507

I still don't get why this `PATH` modification is even necessary, it works without it.