### PR TITLE
compilation should fail if wrong nim_commit was specified

### DIFF
--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -68,7 +68,8 @@ nim_needs_rebuilding() {
 				git remote add extra "${NIM_COMMIT_REPO}"
 			fi
 			git fetch --all --tags --quiet
-			git checkout -q "${NIM_COMMIT}"
+			git checkout -q "${NIM_COMMIT}" ||
+			  { echo "Error: wrong NIM_COMMIT specified:'${NIM_COMMIT}'"; exit 1; }
 		fi
 		# In case the local branch diverged and a fast-forward merge is not possible.
 		git fetch || true


### PR DESCRIPTION
Previously, if there was an unavailable version specified, there was an error message, but then compilation went on using another Nim version.
