### PR TITLE
use the original nim-lang/Nim repo instead of a fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "vendor/Nim"]
 	path = vendor/Nim
-	url = https://github.com/status-im/Nim.git
+	url = https://github.com/nim-lang/Nim.git
 	ignore = dirty
-	branch = nimbus
+	branch = version-2-2

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ You also need to specify it when using this non-default Nim compiler version:
 ### NIM_COMMIT_REPO
 
 `NIM_COMMIT` will try to fetch commits from the 
-[status-im fork](https://github.com/status-im/Nim), followed by the
 [official Nim language repo](https://github.com/nim-lang/Nim). If you want to
 use a fork from somewhere else, you can set this to the repo's URL.
 

--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -106,7 +106,7 @@ update-test:
 update-common: | sanity-checks update-test
 	git submodule foreach --quiet 'git ls-files --exclude-standard --recurse-submodules -z -- ":!:.*" | xargs -0 rm -rf'
 	git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive || true
-	# changing URLs in a submodule's submodule means we have to sync and update twice
+    # changing URLs in a submodule's submodule means we have to sync and update twice
 	git submodule sync --quiet --recursive
 	git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive
 	git submodule foreach --quiet --recursive 'git $(GIT_SUBMODULE_CONFIG) reset --quiet --hard'

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -49,7 +49,7 @@ nim_needs_rebuilding() {
 
 	if [[ ! -e "$NIM_DIR" ]]; then
 		# Shallow clone, optimised for the default NIM_COMMIT value.
-		git clone -q --depth=1 https://github.com/status-im/Nim.git "$NIM_DIR"
+		git clone -q --depth=1 https://github.com/nim-lang/Nim.git "$NIM_DIR"
 	fi
 
 	pushd "${NIM_DIR}" >/dev/null
@@ -58,7 +58,8 @@ nim_needs_rebuilding() {
 		git restore . 2>/dev/null || git reset --hard
 		if ! git checkout -q "${NIM_COMMIT}" 2>/dev/null; then
 			# Pay the price for a non-default NIM_COMMIT here, by fetching everything.
-			# (This includes upstream branches and tags that might be missing from our fork.)
+			# The "upstream" remote (pointing at the same location as the "origin")
+			# is kept for backward compatibility.
 			if ! git remote | grep -q "^upstream$"; then
 				git remote add upstream https://github.com/nim-lang/Nim
 			fi


### PR DESCRIPTION
The status-im/Nim fork is not need anymore, since everything needed is getting fixed and backported in a timely manner in the original repo.

This removes one layer of indirection and we won't have to do pointless pulls/syncs in our fork before upgrading to a newer Nim version.