### PR TITLE
nix: fix nimble package name and hash

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -28,7 +28,7 @@ jobs:
               cpu: amd64
             runs_on: [self-hosted, Linux, X64]
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch }})'
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nix)'
     runs-on: ${{ matrix.runs_on }}
     steps:
       - uses: actions/checkout@v4

--- a/nix/nimble.nix
+++ b/nix/nimble.nix
@@ -7,12 +7,12 @@ let
   nbsVersion = findKeyValue "^[[:space:]]+NIMBLE_COMMIT='([a-f0-9]+)'.*$" ../scripts/build_nim.sh;
   nimVersion = findKeyValue "^[[:space:]]+NimbleStableCommit = \"([a-f0-9]+)\".*$" ../vendor/Nim/koch.nim;
 in pkgs.fetchFromGitHub rec {
-  name = "${owner}-${repo}-src{rev}";
+  name = "${owner}-${repo}-src-${rev}";
   owner = "nim-lang";
   repo = "nimble";
   fetchSubmodules = true;
   # Use Nimbsle verson defined in NBS or default to Nim one.
   rev = if nbsVersion != null then nbsVersion else nimVersion;
   # WARNING: Requires manual updates when Nim compiler version changes.
-  hash = "sha256-DV/cheAoG0UviYEYqfaonhrAl4MgjDwFqbbKx7jUnKE=";
+  hash = "sha256-v0RhIx6ithFJqH6ThKpyvC0JB3CBCevahhCossC+deA";
 }


### PR DESCRIPTION
A typo in package name caused rev to not be included and hash to not be refreshed during builds on machines with cached source.