### PR TITLE
Use git submodule update --force instead of manual delete

### DIFF
--- a/makefiles/targets.mk
+++ b/makefiles/targets.mk
@@ -90,11 +90,10 @@ build-nim: | sanity-checks
 # Check if the update might cause loss of work. Abort, if so, while allowing an override mechanism.
 update-test:
 	TEE_TO_TTY="cat"; if bash -c ": >/dev/tty" &>/dev/null; then TEE_TO_TTY="tee /dev/tty"; fi; \
-	COMMAND="git status --short --untracked-files=no --ignore-submodules=untracked"; \
+	COMMAND="git status --short --untracked-files=normal --ignore-submodules=untracked"; \
 	LINES=$$({ $${COMMAND} | grep 'vendor' && echo ^---top level || true; git submodule foreach --recursive --quiet "$${COMMAND} | grep . && echo ^---\$$name || true"; } | $${TEE_TO_TTY} | wc -l); \
 	if [[ "$${LINES}" -ne "0" && "$(OVERRIDE)" != "1" ]]; then echo -e "\nYou have uncommitted local changes which might be overwritten by the update. Aborting.\nIf you know better, you can use the 'update' target instead of 'update-dev'.\n"; exit 1; fi
 
-#- for each submodule, delete checked out files (that might prevent a fresh checkout); skip dotfiles
 #- in case of submodule URL changes, propagates that change in the parent repo's .git directory
 #- initialises and updates the Git submodules
 #- hard-resets the working copies of submodules
@@ -104,11 +103,10 @@ update-test:
 #- allows parallel building with the '+' prefix
 #- rebuilds the Nim compiler if the corresponding submodule is updated
 update-common: | sanity-checks update-test
-	git submodule foreach --quiet 'git ls-files --exclude-standard --recurse-submodules -z -- ":!:.*" | xargs -0 rm -rf'
-	$(GIT_SUBMODULE_ENV) git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive || true
+	$(GIT_SUBMODULE_ENV) git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive --force || true
     # changing URLs in a submodule's submodule means we have to sync and update twice
 	git submodule sync --quiet --recursive
-	$(GIT_SUBMODULE_ENV) git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive
+	$(GIT_SUBMODULE_ENV) git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive --force
 	$(GIT_SUBMODULE_ENV) git submodule foreach --quiet --recursive 'git $(GIT_SUBMODULE_CONFIG) reset --quiet --hard'
 	find . -type d -name nimcache -print0 | xargs -0 rm -rf
 	$(GET_CURRENT_COMMIT_TIMESTAMP) > $(UPDATE_TIMESTAMP)


### PR DESCRIPTION
When a submodule is locally edited, 'make update' should replace it with the canonical copy. Historically, that didn't work well in all cases, so the strategy was to first delete everything, then re-checkout again. As the repos grew, this became quite slow over time.

From 2020:

- 9c2ef2c introduces the delete
- 254f237 second clean step
- f5278ae widen the delete to all tracked files
- a553d87 recursion
- 1706e69 special chars in filenames
- 8f22777 workaround old git version on Jenkins
- 3ea7d95 silence output
- 3512a86 performance
- 252af3e preserve dotfiles

It seems that the 'git submodule update --force' command achieves same while avoiding slow file system operations. As it also overwrites untracked files that become tracked, extend 'update-test' to also report when the new mechanism might cause loss of work due to untracked files.

- https://git-scm.com/docs/git-submodule

> If --force is specified, the submodule will be checked out
> (using git checkout --force), even if the commit specified
> in the index of the containing repository already matches
> the commit checked out in the submodule.

- https://git-scm.com/docs/git-checkout

> When switching branches, proceed even if the index or the
> working tree differs from HEAD, and even if there are untracked
> files in the way. This is used to throw away local changes and
> any untracked files or directories that are in the way.
>
> When checking out paths from the index, do not fail upon
> unmerged entries; instead, unmerged entries are ignored.